### PR TITLE
Fix publint dep version in site/package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
       '@unocss/vite': ^0.44.7
       get-npm-tarball-url: ^2.0.3
       pako: ^2.0.4
-      publint: workspace:0.1.1
+      publint: workspace:*
       svelte: ^3.52.0
       vite: ^3.2.2
     dependencies:

--- a/site/package.json
+++ b/site/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "get-npm-tarball-url": "^2.0.3",
     "pako": "^2.0.4",
-    "publint": "workspace:0.1.1"
+    "publint": "workspace:*"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^1.1.0",


### PR DESCRIPTION
The following error was happening when running `pnpm i`. I guess this can be `workspace:*` instead of `workspace:0.1.1`.

> ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE  In site: No matching version found for publint@0.1.1 inside the workspace
