### PR TITLE
Updates for main with no exports

### DIFF
--- a/pkg/lib/index.d.ts
+++ b/pkg/lib/index.d.ts
@@ -47,7 +47,7 @@ export type Message =
   | BaseMessage<'FILE_DOES_NOT_EXIST', { filePath: string }>
   | BaseMessage<'MODULE_SHOULD_BE_ESM'>
   | BaseMessage<'HAS_MODULE_BUT_NO_EXPORTS'>
-  | BaseMessage<'HAS_ESM_MAIN_BUT_NO_EXPORTS'>
+  | BaseMessage<'HAS_MAIN_BUT_NO_EXPORTS'>
   | BaseMessage<'EXPORTS_GLOB_NO_MATCHED_FILES'>
   | BaseMessage<
       'EXPORTS_GLOB_NO_DEPRECATED_SUBPATH_MAPPING',

--- a/pkg/src/index.js
+++ b/pkg/src/index.js
@@ -137,14 +137,12 @@ export async function publint({ pkgDir, vfs, level, _include }) {
           type: 'warning'
         })
       }
-      if (expectFormat === 'ESM') {
-        messages.push({
-          code: 'HAS_ESM_MAIN_BUT_NO_EXPORTS',
-          args: {},
-          path: ['main'],
-          type: 'suggestion'
-        })
-      }
+      messages.push({
+        code: 'HAS_MAIN_BUT_NO_EXPORTS',
+        args: {},
+        path: ['main'],
+        type: 'suggestion'
+      })
     })
   }
 

--- a/pkg/src/message.js
+++ b/pkg/src/message.js
@@ -36,9 +36,9 @@ export function printMessage(m, pkg) {
     case 'FILE_DOES_NOT_EXIST':
       // prettier-ignore
       return `${c.bold(fp(m.path))} is ${pv(m.path)} but file does not exist.`
-    case 'HAS_ESM_MAIN_BUT_NO_EXPORTS':
+    case 'HAS_MAIN_BUT_NO_EXPORTS':
       // prettier-ignore
-      return `${c.bold('pkg.main')} is an ESM file, but it is usually better to use ${c.bold('pkg.exports')} instead, and remove ${c.bold('pkg.main')} alongside, as compatible NodeJS versions support it as well. (This will be a breaking change)`
+      return 'pkg.main will be ignored by modern tooling since pkg.exports is present and can generally be removed. (This will be a breaking change as removing it drops support for legacy tooling).'
     case 'HAS_MODULE_BUT_NO_EXPORTS':
       // prettier-ignore
       return `${c.bold('pkg.module')} is used to output ESM, but ${c.bold('pkg.exports')} is not defined. As NodeJS doesn't read ${c.bold('pkg.module')}, the ESM output may be skipped. Consider adding ${c.bold('pkg.exports')} to export the ESM output. ${c.bold('pkg.module')} can usually be removed alongside too. (This will be a breaking change)`

--- a/site/rules.html
+++ b/site/rules.html
@@ -41,7 +41,7 @@
         If the package has a <code>module</code> entry without a
         <code>exports</code> entry, suggest using <code>exports</code> instead.
       </p>
-      <h2><code>HAS_ESM_MAIN_BUT_NO_EXPORTS</code></h2>
+      <h2><code>HAS_MAIN_BUT_NO_EXPORTS</code></h2>
       <p>
         If the <code>main</code> entrypoint is an ES module, you can likely
         remove it as environments that supports so also supports

--- a/site/src/utils/message.js
+++ b/site/src/utils/message.js
@@ -28,9 +28,9 @@ export function printMessage(m, pkg) {
     case 'FILE_DOES_NOT_EXIST':
       // prettier-ignore
       return `File does not exist`
-    case 'HAS_ESM_MAIN_BUT_NO_EXPORTS':
+    case 'HAS_MAIN_BUT_NO_EXPORTS':
       // prettier-ignore
-      return `${bold('pkg.main')} is an ESM file, but it is usually better to use ${bold('pkg.exports')} instead, and remove ${bold('pkg.main')} alongside, as compatible NodeJS versions support it as well. (This will be a breaking change)`
+      return 'pkg.main will be ignored by modern tooling since pkg.exports is present and can generally be removed. (This will be a breaking change as removing it drops support for legacy tooling).'
     case 'HAS_MODULE_BUT_NO_EXPORTS':
       // prettier-ignore
       return `${bold('pkg.module')} is used to output ESM, but ${bold('pkg.exports')} is not defined. As NodeJS doesn't read ${bold('pkg.module')}, the ESM output may be skipped. Consider adding ${bold('pkg.exports')} to export the ESM output. ${bold('pkg.module')} can usually be removed alongside too. (This will be a breaking change)`


### PR DESCRIPTION
The current message is quite confusing to me because `exports` doesn't have anything to do with ESM. You can use it with CJS as well. This updates it to apply whether the code is CJS or ESM.