### PR TITLE
Check that `module` preceeds `import` and `require` in exports definitions

### DIFF
--- a/pkg/index.d.ts
+++ b/pkg/index.d.ts
@@ -58,8 +58,10 @@ export type Message =
       }
     >
   | BaseMessage<'EXPORTS_TYPES_SHOULD_BE_FIRST'>
-  | BaseMessage<'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT'>
-  | BaseMessage<'EXPORTS_MODULE_SHOULD_PRECEED_REQUIRE'>
+  | BaseMessage<
+      'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE',
+      { conditions: string[] }
+    >
   | BaseMessage<'EXPORTS_DEFAULT_SHOULD_BE_LAST'>
   | BaseMessage<'EXPORTS_MODULE_SHOULD_BE_ESM'>
   | BaseMessage<'EXPORTS_VALUE_INVALID', { suggestValue: string }>

--- a/pkg/index.d.ts
+++ b/pkg/index.d.ts
@@ -58,6 +58,8 @@ export type Message =
       }
     >
   | BaseMessage<'EXPORTS_TYPES_SHOULD_BE_FIRST'>
+  | BaseMessage<'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT'>
+  | BaseMessage<'EXPORTS_MODULE_SHOULD_PRECEED_REQUIRE'>
   | BaseMessage<'EXPORTS_DEFAULT_SHOULD_BE_LAST'>
   | BaseMessage<'EXPORTS_MODULE_SHOULD_BE_ESM'>
   | BaseMessage<'EXPORTS_VALUE_INVALID', { suggestValue: string }>

--- a/pkg/src/index.js
+++ b/pkg/src/index.js
@@ -493,6 +493,34 @@ export async function publint({ pkgDir, vfs, level, strict, _packedFiles }) {
         }
       }
 
+      // a 'module' export should always preceed 'require'
+      if (
+        'module' in exports &&
+        'require' in exports &&
+        exportsKeys.indexOf('module') > exportsKeys.indexOf('require')
+      ) {
+        messages.push({
+          code: 'EXPORTS_MODULE_SHOULD_PRECEED_REQUIRE',
+          args: {},
+          path: currentPath.concat('module'),
+          type: 'error'
+        })
+      }
+
+      // a 'module' export should always preceed 'import'
+      if (
+        'module' in exports &&
+        'import' in exports &&
+        exportsKeys.indexOf('module') > exportsKeys.indexOf('import')
+      ) {
+        messages.push({
+          code: 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT',
+          args: {},
+          path: currentPath.concat('module'),
+          type: 'error'
+        })
+      }
+
       // the default export should be the last condition
       if (
         'default' in exports &&

--- a/pkg/src/index.js
+++ b/pkg/src/index.js
@@ -493,32 +493,30 @@ export async function publint({ pkgDir, vfs, level, strict, _packedFiles }) {
         }
       }
 
-      // a 'module' export should always preceed 'require'
-      if (
-        'module' in exports &&
-        'require' in exports &&
-        exportsKeys.indexOf('module') > exportsKeys.indexOf('require')
-      ) {
-        messages.push({
-          code: 'EXPORTS_MODULE_SHOULD_PRECEED_REQUIRE',
-          args: {},
-          path: currentPath.concat('module'),
-          type: 'error'
-        })
-      }
+      // a 'module' export should always preceed 'import' or 'require'
+      if ('module' in exports) {
+        const conditions = []
+        if (
+          'require' in exports &&
+          exportsKeys.indexOf('module') > exportsKeys.indexOf('require')
+        ) {
+          conditions.push('require')
+        }
+        if (
+          'import' in exports &&
+          exportsKeys.indexOf('module') > exportsKeys.indexOf('import')
+        ) {
+          conditions.push('import')
+        }
 
-      // a 'module' export should always preceed 'import'
-      if (
-        'module' in exports &&
-        'import' in exports &&
-        exportsKeys.indexOf('module') > exportsKeys.indexOf('import')
-      ) {
-        messages.push({
-          code: 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT',
-          args: {},
-          path: currentPath.concat('module'),
-          type: 'error'
-        })
+        if (conditions.length > 0) {
+          messages.push({
+            code: 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE',
+            args: { conditions },
+            path: currentPath.concat('module'),
+            type: 'error'
+          })
+        }
       }
 
       // the default export should be the last condition

--- a/pkg/src/message.js
+++ b/pkg/src/message.js
@@ -56,12 +56,9 @@ export function printMessage(m, pkg) {
     case 'EXPORTS_TYPES_SHOULD_BE_FIRST':
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be the first in the object as required by TypeScript.`
-    case 'EXPORTS_MODULE_SHOULD_PRECEED_REQUIRE':
+    case 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE':
       // prettier-ignore
-      return `${c.bold(fp(m.path))} should come before 'require' so it can take precedence when used by a bundler.`
-    case 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT':
-      // prettier-ignore
-      return `${c.bold(fp(m.path))} should come before 'import' so it can take precedence when used by a bundler.`
+      return `${c.bold(fp(m.path))} should come before ${m.args.conditions.map(cond => `'${cond}'`).join(' or ')} so it can take precedence when used by a bundler.`
     case 'EXPORTS_DEFAULT_SHOULD_BE_LAST':
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be the last in the object so it doesn't take precedence over the keys following it.`

--- a/pkg/src/message.js
+++ b/pkg/src/message.js
@@ -58,7 +58,7 @@ export function printMessage(m, pkg) {
       return `${c.bold(fp(m.path))} should be the first in the object as required by TypeScript.`
     case 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE':
       // prettier-ignore
-      return `${c.bold(fp(m.path))} should come before ${m.args.conditions.map(cond => `'${cond}'`).join(' or ')} so it can take precedence when used by a bundler.`
+      return `${c.bold(fp(m.path))} should come before ${m.args.conditions.map(cond => `'${cond}'`).join(' and ')} so it can take precedence when used by a bundler.`
     case 'EXPORTS_DEFAULT_SHOULD_BE_LAST':
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be the last in the object so it doesn't take precedence over the keys following it.`

--- a/pkg/src/message.js
+++ b/pkg/src/message.js
@@ -56,9 +56,16 @@ export function printMessage(m, pkg) {
     case 'EXPORTS_TYPES_SHOULD_BE_FIRST':
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be the first in the object as required by TypeScript.`
-    case 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE':
+    case 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE': {
+      let conditions = `the ${m.args.conditions
+        .map((cond) => c.bold(cond))
+        .join(' and ')} condition`
+      if (m.args.conditions.length !== 1) {
+        conditions += 's'
+      }
       // prettier-ignore
-      return `${c.bold(fp(m.path))} should come before ${m.args.conditions.map(cond => `'${cond}'`).join(' and ')} so it can take precedence when used by a bundler.`
+      return `${c.bold(fp(m.path))} should come before ${conditions} so it can take precedence when used by a bundler.`
+    }
     case 'EXPORTS_DEFAULT_SHOULD_BE_LAST':
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be the last in the object so it doesn't take precedence over the keys following it.`

--- a/pkg/src/message.js
+++ b/pkg/src/message.js
@@ -56,6 +56,12 @@ export function printMessage(m, pkg) {
     case 'EXPORTS_TYPES_SHOULD_BE_FIRST':
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be the first in the object as required by TypeScript.`
+    case 'EXPORTS_MODULE_SHOULD_PRECEED_REQUIRE':
+      // prettier-ignore
+      return `${c.bold(fp(m.path))} should come before 'require' so it can take precedence when used by a bundler.`
+    case 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT':
+      // prettier-ignore
+      return `${c.bold(fp(m.path))} should come before 'import' so it can take precedence when used by a bundler.`
     case 'EXPORTS_DEFAULT_SHOULD_BE_LAST':
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be the last in the object so it doesn't take precedence over the keys following it.`

--- a/pkg/tests/fixtures/exports-module/main.js
+++ b/pkg/tests/fixtures/exports-module/main.js
@@ -1,0 +1,1 @@
+module.exports = 'foo'

--- a/pkg/tests/fixtures/exports-module/main.mjs
+++ b/pkg/tests/fixtures/exports-module/main.mjs
@@ -1,0 +1,1 @@
+export const foo = 'bar'

--- a/pkg/tests/fixtures/exports-module/package.json
+++ b/pkg/tests/fixtures/exports-module/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "publint-test-exports-module",
+  "version": "0.0.1",
+  "private": true,
+  "exports": {
+    ".": {
+      "import": "./main.mjs",
+      "require": "./main.js",
+      "module": "./main.mjs"
+    }
+  }
+}

--- a/pkg/tests/fixtures/exports-module/package.json
+++ b/pkg/tests/fixtures/exports-module/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "publint-test-exports-module",
+  "name": "publint-exports-module",
   "version": "0.0.1",
   "private": true,
   "exports": {

--- a/pkg/tests/playground.js
+++ b/pkg/tests/playground.js
@@ -28,10 +28,7 @@ testFixture('missing-files', [
 
 testFixture('no-exports-module', [])
 
-testFixture('exports-module', [
-  'EXPORTS_MODULE_SHOULD_PRECEED_REQUIRE',
-  'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT'
-])
+testFixture('exports-module', ['EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE'])
 
 testFixture('publish-config', ['USE_EXPORTS_BROWSER', 'FILE_DOES_NOT_EXIST'])
 

--- a/pkg/tests/playground.js
+++ b/pkg/tests/playground.js
@@ -28,6 +28,11 @@ testFixture('missing-files', [
 
 testFixture('no-exports-module', [])
 
+testFixture('exports-module', [
+  'EXPORTS_MODULE_SHOULD_PRECEED_REQUIRE',
+  'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT'
+])
+
 testFixture('publish-config', ['USE_EXPORTS_BROWSER', 'FILE_DOES_NOT_EXIST'])
 
 testFixture('test-1', ['TYPES_NOT_EXPORTED', 'FILE_INVALID_FORMAT'])

--- a/site/rules.md
+++ b/site/rules.md
@@ -57,13 +57,9 @@ If the `exports` field contains glob paths, but it doesn't match any files, repo
 
 The `exports` field should not have globs defined with trailing slashes. It is [deprecated](https://nodejs.org/docs/latest-v16.x/api/packages.html#subpath-folder-mappings) and should use [subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns), e.g. a trailing `/*` instead.
 
-## `EXPORTS_MODULE_SHOULD_PRECEED_IMPORT`
+## `EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE`
 
-Ensure `module` condition to come before `import` condition. Due to the way conditions are matched top-to-bottom, the `module` condition (used in bundler contexts only) must come before an `import` definition, so it has the opportunity to take precedence.
-
-## `EXPORTS_MODULE_SHOULD_PRECEED_REQUIRE`
-
-Ensure `module` condition to come before `require` condition. Due to the way conditions are matched top-to-bottom, the `module` condition (used in bundler contexts only) must come before a `require` definition, so it has the opportunity to take precedence.
+Ensure `module` condition to come before `import` or `require` conditions. Due to the way conditions are matched top-to-bottom, the `module` condition (used in bundler contexts only) must come before an `import` or `require` definition, so it has the opportunity to take precedence.
 
 ## `EXPORTS_TYPES_SHOULD_BE_FIRST`
 

--- a/site/rules.md
+++ b/site/rules.md
@@ -57,6 +57,14 @@ If the `exports` field contains glob paths, but it doesn't match any files, repo
 
 The `exports` field should not have globs defined with trailing slashes. It is [deprecated](https://nodejs.org/docs/latest-v16.x/api/packages.html#subpath-folder-mappings) and should use [subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns), e.g. a trailing `/*` instead.
 
+## `EXPORTS_MODULE_SHOULD_PRECEED_IMPORT`
+
+Ensure `module` condition to come before `import` condition. Due to the way conditions are matched top-to-bottom, the `module` condition (used in bundler contexts only) must come before an `import` definition, so it has the opportunity to take precedence.
+
+## `EXPORTS_MODULE_SHOULD_PRECEED_REQUIRE`
+
+Ensure `module` condition to come before `require` condition. Due to the way conditions are matched top-to-bottom, the `module` condition (used in bundler contexts only) must come before a `require` definition, so it has the opportunity to take precedence.
+
 ## `EXPORTS_TYPES_SHOULD_BE_FIRST`
 
 Ensure `types` condition to be the first. The [TypeScript docs](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) recommends so, but it's also because the `exports` field is order-based.

--- a/site/src/utils/message.js
+++ b/site/src/utils/message.js
@@ -64,7 +64,7 @@ function messageToString(m, pkg) {
       return `Should be the first in the object as required by TypeScript.`
     case 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE':
       // prettier-ignore
-      return `${bold(fp(m.path))} should come before ${m.args.conditions.map(cond => `'${cond}'`).join(' or ')} so it can take precedence when used by a bundler.`
+      return `${bold(fp(m.path))} should come before ${m.args.conditions.map(cond => `'${cond}'`).join(' and ')} so it can take precedence when used by a bundler.`
     case 'EXPORTS_DEFAULT_SHOULD_BE_LAST':
       // prettier-ignore
       return `Should be the last in the object so it doesn't take precedence over the keys following it.`

--- a/site/src/utils/message.js
+++ b/site/src/utils/message.js
@@ -62,6 +62,9 @@ function messageToString(m, pkg) {
     case 'EXPORTS_TYPES_SHOULD_BE_FIRST':
       // prettier-ignore
       return `Should be the first in the object as required by TypeScript.`
+    case 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE':
+      // prettier-ignore
+      return `${bold(fp(m.path))} should come before ${m.args.conditions.map(cond => `'${cond}'`).join(' or ')} so it can take precedence when used by a bundler.`
     case 'EXPORTS_DEFAULT_SHOULD_BE_LAST':
       // prettier-ignore
       return `Should be the last in the object so it doesn't take precedence over the keys following it.`

--- a/site/src/utils/message.js
+++ b/site/src/utils/message.js
@@ -62,9 +62,16 @@ function messageToString(m, pkg) {
     case 'EXPORTS_TYPES_SHOULD_BE_FIRST':
       // prettier-ignore
       return `Should be the first in the object as required by TypeScript.`
-    case 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE':
+    case 'EXPORTS_MODULE_SHOULD_PRECEED_IMPORT_REQUIRE': {
+      let conditions = `the ${m.args.conditions
+        .map((cond) => bold(cond))
+        .join(' and ')} condition`
+      if (m.args.conditions.length !== 1) {
+        conditions += 's'
+      }
       // prettier-ignore
-      return `${bold(fp(m.path))} should come before ${m.args.conditions.map(cond => `'${cond}'`).join(' and ')} so it can take precedence when used by a bundler.`
+      return `Should come before ${conditions} so it can take precedence when used by a bundler.`
+    }
     case 'EXPORTS_DEFAULT_SHOULD_BE_LAST':
       // prettier-ignore
       return `Should be the last in the object so it doesn't take precedence over the keys following it.`


### PR DESCRIPTION
This provides a fix for common bugs like this:

    {
      "exports": {
        ".": {
          "import": "./dist/index.mjs",
          "require": "./dist/index.js",
          "module": "./dist/index.mjs",  // ⚠️
        }
      }
    }

Due to the way conditions are checked top-to-bottom, the `module` definition has no chance to take precedence over `import` and `require`—which is typically the whole point of including `module`. Bundler implementations may chose to not respect definition order (so some bundlers may work _despite_ the incorrect order of the `module` field), but it's not the way the conditions are supposed to be checked. By enforcing `module` to appear before `import` and/or `require`, this problem is circumvented and should work in _all_ bundlers.

The fix for the above is to move the `"module"` definition up:

    {
      "exports": {
        ".": {
          "module": "./dist/index.mjs",  // ✅
          "import": "./dist/index.mjs",
          "require": "./dist/index.js",
        }
      }
    }

Based on this description of [how conditions work](https://esbuild.github.io/api/#how-conditions-work).