### PR TITLE
Don't enforce `module` to precede `import` per se

### DIFF
--- a/pkg/index.d.ts
+++ b/pkg/index.d.ts
@@ -59,8 +59,7 @@ export type Message =
     >
   | BaseMessage<'EXPORTS_TYPES_SHOULD_BE_FIRST'>
   | BaseMessage<
-      'EXPORTS_MODULE_SHOULD_PRECEDE_IMPORT_REQUIRE',
-      { conditions: string[] }
+      'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE'
     >
   | BaseMessage<'EXPORTS_DEFAULT_SHOULD_BE_LAST'>
   | BaseMessage<'EXPORTS_MODULE_SHOULD_BE_ESM'>

--- a/pkg/index.d.ts
+++ b/pkg/index.d.ts
@@ -58,9 +58,7 @@ export type Message =
       }
     >
   | BaseMessage<'EXPORTS_TYPES_SHOULD_BE_FIRST'>
-  | BaseMessage<
-      'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE'
-    >
+  | BaseMessage<'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE'>
   | BaseMessage<'EXPORTS_DEFAULT_SHOULD_BE_LAST'>
   | BaseMessage<'EXPORTS_MODULE_SHOULD_BE_ESM'>
   | BaseMessage<'EXPORTS_VALUE_INVALID', { suggestValue: string }>

--- a/pkg/src/index.js
+++ b/pkg/src/index.js
@@ -495,13 +495,17 @@ export async function publint({ pkgDir, vfs, level, strict, _packedFiles }) {
 
       // if there is a 'require' and a 'module' condition at the same level,
       // then 'module' should always precede 'require'
-      if ('module' in exports && 'require' in exports && exportsKeys.indexOf('module') > exportsKeys.indexOf('require')) {
-          messages.push({
-            code: 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE',
-            args: {},
-            path: currentPath.concat('module'),
-            type: 'error'
-          })
+      if (
+        'module' in exports &&
+        'require' in exports &&
+        exportsKeys.indexOf('module') > exportsKeys.indexOf('require')
+      ) {
+        messages.push({
+          code: 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE',
+          args: {},
+          path: currentPath.concat('module'),
+          type: 'error'
+        })
       }
 
       // the default export should be the last condition

--- a/pkg/src/index.js
+++ b/pkg/src/index.js
@@ -493,30 +493,15 @@ export async function publint({ pkgDir, vfs, level, strict, _packedFiles }) {
         }
       }
 
-      // a 'module' export should always precede 'import' or 'require'
-      if ('module' in exports) {
-        const conditions = []
-        if (
-          'require' in exports &&
-          exportsKeys.indexOf('module') > exportsKeys.indexOf('require')
-        ) {
-          conditions.push('require')
-        }
-        if (
-          'import' in exports &&
-          exportsKeys.indexOf('module') > exportsKeys.indexOf('import')
-        ) {
-          conditions.push('import')
-        }
-
-        if (conditions.length > 0) {
+      // if there is a 'require' and a 'module' condition at the same level,
+      // then 'module' should always precede 'require'
+      if ('module' in exports && 'require' in exports && exportsKeys.indexOf('module') > exportsKeys.indexOf('require')) {
           messages.push({
-            code: 'EXPORTS_MODULE_SHOULD_PRECEDE_IMPORT_REQUIRE',
-            args: { conditions },
+            code: 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE',
+            args: {},
             path: currentPath.concat('module'),
             type: 'error'
           })
-        }
       }
 
       // the default export should be the last condition

--- a/pkg/src/message.js
+++ b/pkg/src/message.js
@@ -56,15 +56,9 @@ export function printMessage(m, pkg) {
     case 'EXPORTS_TYPES_SHOULD_BE_FIRST':
       // prettier-ignore
       return `${c.bold(fp(m.path))} should be the first in the object as required by TypeScript.`
-    case 'EXPORTS_MODULE_SHOULD_PRECEDE_IMPORT_REQUIRE': {
-      let conditions = `the ${m.args.conditions
-        .map((cond) => `"${c.bold(cond)}"`)
-        .join(' and ')} condition`
-      if (m.args.conditions.length !== 1) {
-        conditions += 's'
-      }
+    case 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE': {
       // prettier-ignore
-      return `${c.bold(fp(m.path))} should come before ${conditions} so it can take precedence when used by a bundler.`
+      return `${c.bold(fp(m.path))} should come before the "require" condition so it can take precedence when used by a bundler.`
     }
     case 'EXPORTS_DEFAULT_SHOULD_BE_LAST':
       // prettier-ignore

--- a/pkg/tests/playground.js
+++ b/pkg/tests/playground.js
@@ -28,7 +28,7 @@ testFixture('missing-files', [
 
 testFixture('no-exports-module', [])
 
-testFixture('exports-module', ['EXPORTS_MODULE_SHOULD_PRECEDE_IMPORT_REQUIRE'])
+testFixture('exports-module', ['EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE'])
 
 testFixture('publish-config', ['USE_EXPORTS_BROWSER', 'FILE_DOES_NOT_EXIST'])
 

--- a/site/rules.md
+++ b/site/rules.md
@@ -57,9 +57,9 @@ If the `"exports"` field contains glob paths, but it doesn't match any files, re
 
 The `"exports"` field should not have globs defined with trailing slashes. It is [deprecated](https://nodejs.org/docs/latest-v16.x/api/packages.html#subpath-folder-mappings) and should use [subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns), e.g. a trailing `/*` instead.
 
-## `EXPORTS_MODULE_SHOULD_PRECEDE_IMPORT_REQUIRE`
+## `EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE`
 
-Ensure the `"module"` condition comes before the `"import"` and `"require"` conditions. Due to the way conditions are matched top-to-bottom, the `"module"` condition (used in bundler contexts only) must come before an `"import"` or `"require"` condition, so it has the opportunity to take precedence.
+Ensure the `"module"` condition comes before the `"require"` condition. Due to the way conditions are matched top-to-bottom, the `"module"` condition (used in bundler contexts only) must come before a `"require"` condition, so it has the opportunity to take precedence.
 
 ## `EXPORTS_TYPES_SHOULD_BE_FIRST`
 

--- a/site/src/utils/message.js
+++ b/site/src/utils/message.js
@@ -62,15 +62,9 @@ function messageToString(m, pkg) {
     case 'EXPORTS_TYPES_SHOULD_BE_FIRST':
       // prettier-ignore
       return `Should be the first in the object as required by TypeScript.`
-    case 'EXPORTS_MODULE_SHOULD_PRECEDE_IMPORT_REQUIRE': {
-      let conditions = `the ${m.args.conditions
-        .map((cond) => `"${bold(cond)}"`)
-        .join(' and ')} condition`
-      if (m.args.conditions.length !== 1) {
-        conditions += 's'
-      }
+    case 'EXPORTS_MODULE_SHOULD_PRECEDE_REQUIRE': {
       // prettier-ignore
-      return `Should come before ${conditions} so it can take precedence when used by a bundler.`
+      return `Should come before the "require" condition so it can take precedence when used by a bundler.`
     }
     case 'EXPORTS_DEFAULT_SHOULD_BE_LAST':
       // prettier-ignore


### PR DESCRIPTION
The lint rule I contributed recently in https://github.com/bluwy/publint/pull/49 may have been a tad bit too strict. Some package authors prefer to use the `module` condition to override the `require` (or `default`) condition only, but not using it for `import` statements. That should be fine. The purpose of the bundler-specific `module` condition is to allow you to override/intercept `require()`s mostly, and instruct the bundler to include the ESM version instead.

As a package author, you can still also decide to place the `module` condition before the `import` and as such use it to _also_ intercept `import` statements. Both approaches are fine, as a `module` and `import` definition will typically resolve to the same module in practice. So it's mostly an author preference, and not something we should enforce with a lint rule.

This PR loosens the check by only enforcing that `module` precedes `require`. It drops the requirement that it also precedes `import`.

An example of a project that got a false positive from the too-strict check is https://publint.dev/zustand. They use `import`, and only fall back to a `module` redirect for `require()` statements (via their `default` condition). That's perfectly fine.

---

For example, examples 1 and 2 are fine, but example 3 is not (the "module" will never be used):

Example 1:

```js
{
  ".": {
    "module": "index.mjs",  // 👍 Still fine
    "import": "index.mjs",
    "require": "index.cjs",
  }
}
```

Example 2:

```js
{
  ".": {
    "import": "index.mjs",
    "module": "index.mjs",  // 👍 Previously rejected, now also fine
    "require": "index.cjs",
  }
}
```

Example 3:

```js
{
  ".": {
    "import": "index.mjs",
    "require": "index.cjs",
    "module": "index.mjs",  // ❌ Lint error, because this condition will never be used
  }
}
```
