### PR TITLE
Fix EXPORT_TYPES_INVALID_FORMAT example

### DIFF
--- a/site/rules.md
+++ b/site/rules.md
@@ -97,7 +97,7 @@ An example of a correct configuration looks like this:
       "types": "./index.d.mts",
       "default": "./index.mjs"
     },
-    "import": {
+    "require": {
       "types": "./index.d.cts",
       "default": "./index.cjs"
     }


### PR DESCRIPTION
Changed `import` to `require` for the CJS exports.