### PR TITLE
Lint typings field file existence

### DIFF
--- a/pkg/src/index.js
+++ b/pkg/src/index.js
@@ -210,7 +210,14 @@ export async function publint({ pkgDir, vfs, level, strict, _packedFiles }) {
   }
 
   // check file existence for other known package fields
-  const knownFields = ['types', 'typings', 'jsnext:main', 'jsnext', 'unpkg', 'jsdelivr']
+  const knownFields = [
+    'types',
+    'typings',
+    'jsnext:main',
+    'jsnext',
+    'unpkg',
+    'jsdelivr'
+  ]
   // if has typesVersions field, it complicates `types`/`typings` field resolution a lot.
   // for now skip it, but further improvements are tracked at
   // https://github.com/bluwy/publint/issues/42

--- a/pkg/src/index.js
+++ b/pkg/src/index.js
@@ -210,12 +210,12 @@ export async function publint({ pkgDir, vfs, level, strict, _packedFiles }) {
   }
 
   // check file existence for other known package fields
-  const knownFields = ['types', 'jsnext:main', 'jsnext', 'unpkg', 'jsdelivr']
-  // if has typesVersions field, it complicates `types` field resolution a lot.
+  const knownFields = ['types', 'typings', 'jsnext:main', 'jsnext', 'unpkg', 'jsdelivr']
+  // if has typesVersions field, it complicates `types`/`typings` field resolution a lot.
   // for now skip it, but further improvements are tracked at
   // https://github.com/bluwy/publint/issues/42
   if (getPublishedField(rootPkg, 'typesVersions')[0]) {
-    knownFields.splice(0, 1)
+    knownFields.splice(0, 2)
   }
   for (const field of knownFields) {
     const [fieldValue, fieldPkgPath] = getPublishedField(rootPkg, field)
@@ -723,8 +723,11 @@ export async function publint({ pkgDir, vfs, level, strict, _packedFiles }) {
     let typesFilePath
     if (exportsKey == null || exportsKey === '.') {
       const [types] = getPublishedField(rootPkg, 'types')
+      const [typings] = getPublishedField(rootPkg, 'typings')
       if (types) {
         typesFilePath = types
+      } else if (typings) {
+        typesFilePath = typings
       } else if (await readFile(vfs.pathJoin(pkgDir, './index.d.ts'))) {
         typesFilePath = './index.d.ts'
       }

--- a/pkg/tests/fixtures/test-2/package.json
+++ b/pkg/tests/fixtures/test-2/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "main": "./main.mjs",
   "browser": "./lib/bar.js",
+  "typings": "./doesn't-exist.d.ts",
   "exports": {
     "./*.js": "./lib/*.js",
     "./browser": {

--- a/pkg/tests/playground.js
+++ b/pkg/tests/playground.js
@@ -37,6 +37,7 @@ testFixture('test-1', ['FILE_INVALID_FORMAT', 'TYPES_NOT_EXPORTED'])
 testFixture('test-2', [
   'EXPORTS_MODULE_SHOULD_BE_ESM',
   'EXPORTS_VALUE_INVALID',
+  'FILE_DOES_NOT_EXIST',
   'FILE_INVALID_FORMAT',
   'FILE_INVALID_FORMAT',
   'USE_EXPORTS_BROWSER'
@@ -47,6 +48,7 @@ testFixture(
   [
     'EXPORTS_MODULE_SHOULD_BE_ESM',
     'EXPORTS_VALUE_INVALID',
+    'FILE_DOES_NOT_EXIST',
     'FILE_INVALID_FORMAT',
     'FILE_INVALID_FORMAT'
   ],
@@ -55,7 +57,7 @@ testFixture(
 
 testFixture(
   'test-2 (level: error)',
-  ['EXPORTS_MODULE_SHOULD_BE_ESM', 'EXPORTS_VALUE_INVALID'],
+  ['EXPORTS_MODULE_SHOULD_BE_ESM', 'EXPORTS_VALUE_INVALID', 'FILE_DOES_NOT_EXIST'],
   { level: 'error' }
 )
 
@@ -64,6 +66,7 @@ testFixture(
   [
     'EXPORTS_MODULE_SHOULD_BE_ESM',
     'EXPORTS_VALUE_INVALID',
+    'FILE_DOES_NOT_EXIST',
     'FILE_INVALID_FORMAT',
     'FILE_INVALID_FORMAT'
   ],
@@ -75,6 +78,7 @@ testFixture(
   [
     { code: 'EXPORTS_MODULE_SHOULD_BE_ESM', type: 'error' },
     { code: 'EXPORTS_VALUE_INVALID', type: 'error' },
+    { code: 'FILE_DOES_NOT_EXIST', type: 'error' },
     { code: 'FILE_INVALID_FORMAT', type: 'error' },
     { code: 'FILE_INVALID_FORMAT', type: 'error' },
     { code: 'USE_EXPORTS_BROWSER', type: 'suggestion' }

--- a/pkg/tests/playground.js
+++ b/pkg/tests/playground.js
@@ -57,7 +57,11 @@ testFixture(
 
 testFixture(
   'test-2 (level: error)',
-  ['EXPORTS_MODULE_SHOULD_BE_ESM', 'EXPORTS_VALUE_INVALID', 'FILE_DOES_NOT_EXIST'],
+  [
+    'EXPORTS_MODULE_SHOULD_BE_ESM',
+    'EXPORTS_VALUE_INVALID',
+    'FILE_DOES_NOT_EXIST'
+  ],
   { level: 'error' }
 )
 


### PR DESCRIPTION
`typings` field can also be used to point to the type definition file. (it's just an alias of `types` field)
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

I simply added to the file existence check.

I can think of setting different values to `types` and `typings` but I believe no one would do that, so I didn't add that rule.
