### PR TITLE
Resolve site ts error

### DIFF
--- a/site/src/components/PkgNode.svelte
+++ b/site/src/components/PkgNode.svelte
@@ -21,7 +21,7 @@
 
   $: isValueArray = Array.isArray(value)
   $: isValueObject = value && typeof value === 'object'
-  $: keyText = key && isNaN(parseInt(key)) ? `"${key}": ` : ''
+  $: keyText = key && isNaN(parseInt(`${key}`)) ? `"${key}": ` : ''
 
   $: matchedMessages = messages.filter(
     (v) => v.path.length && isArrayEqual(paths, v.path)


### PR DESCRIPTION
The type of `key` does not match the parameter type of `parseInt`.

![image](https://github.com/bluwy/publint/assets/24516654/946a3088-1a00-4555-b3aa-04a7c8c5c852)
