### PR TITLE
fix: version switch title not updated

### DIFF
--- a/site/src/pages/Package.svelte
+++ b/site/src/pages/Package.svelte
@@ -140,9 +140,7 @@
 </script>
 
 <svelte:head>
-  {#if npmPkgName && npmPkgVersion}
-    <title>{npmPkgName} - {npmPkgVersion} - publint</title>
-  {/if}
+  <title>{npmPkgName} - {npmPkgVersion ? npmPkgVersion + ' - ' : ''} publint</title>
 </svelte:head>
 
 <main class="flex flex-col items-center min-h-screen p-4">


### PR DESCRIPTION
After the version switch, the corresponding version in the title has not been updated.
I'm new to svelte and I tried fixing it, not sure if this modification is correct.