### PR TITLE
Add a warning for jsnext field

### DIFF
--- a/pkg/index.d.ts
+++ b/pkg/index.d.ts
@@ -106,6 +106,7 @@ export type Message =
         browserishCondition: string
       }
     >
+  | BaseMessage<'DEPRECATED_FIELD_JSNEXT'>
 
 export interface Options {
   /**

--- a/pkg/src/message.js
+++ b/pkg/src/message.js
@@ -147,6 +147,10 @@ export function formatMessage(m, pkg) {
     case 'EXPORTS_VALUE_CONFLICTS_WITH_BROWSER':
       // prettier-ignore
       return `${c.bold(fp(m.path))} is ${c.bold(pv(m.path))} which also matches ${c.bold(fp(m.args.browserPath))}: "${c.bold(pv(m.args.browserPath))}", which overrides the path when building the library with the "${c.bold(m.args.browserishCondition)}" condition. This is usually unintentional and may cause build issues. Consider using a different file name for ${c.bold(pv(m.path))}.`
+    case 'DEPRECATED_FIELD_JSNEXT':
+      return `${c.bold(fp(m.path))} is deprecated. ${c.bold(
+        'pkg.module'
+      )} should be used instead.`
     default:
       return
   }

--- a/pkg/src/message.js
+++ b/pkg/src/message.js
@@ -148,9 +148,8 @@ export function formatMessage(m, pkg) {
       // prettier-ignore
       return `${c.bold(fp(m.path))} is ${c.bold(pv(m.path))} which also matches ${c.bold(fp(m.args.browserPath))}: "${c.bold(pv(m.args.browserPath))}", which overrides the path when building the library with the "${c.bold(m.args.browserishCondition)}" condition. This is usually unintentional and may cause build issues. Consider using a different file name for ${c.bold(pv(m.path))}.`
     case 'DEPRECATED_FIELD_JSNEXT':
-      return `${c.bold(fp(m.path))} is deprecated. ${c.bold(
-        'pkg.module'
-      )} should be used instead.`
+      // prettier-ignore
+      return `${c.bold(fp(m.path))} is deprecated. ${c.bold('pkg.module')} should be used instead.`
     default:
       return
   }

--- a/pkg/tests/fixtures/deprecated-fields/package.json
+++ b/pkg/tests/fixtures/deprecated-fields/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "publint-glob-deprecated",
+  "version": "0.0.1",
+  "private": true,
+  "main": "./index.js",
+  "jsnext": "./index.js",
+  "jsnext:main": "./index.js"
+}

--- a/pkg/tests/playground.js
+++ b/pkg/tests/playground.js
@@ -134,6 +134,11 @@ testFixture('types-versions', [])
 
 testFixture('umd', ['FILE_INVALID_FORMAT', 'FILE_INVALID_FORMAT'])
 
+testFixture('deprecated-fields', [
+  'DEPRECATED_FIELD_JSNEXT',
+  'DEPRECATED_FIELD_JSNEXT'
+])
+
 /**
  * @typedef {{
  *  level?: import('../index.d.ts').Options['level']

--- a/site/rules.md
+++ b/site/rules.md
@@ -229,4 +229,4 @@ To fix this, you can rename `"./lib.server.js"` to `"./lib.worker.js"` for examp
 
 ## `DEPRECATED_FIELD_JSNEXT`
 
-`"jsnext:main"` field and `"jsnext"` field are deprecated. `"module"` field should be used instead.
+The `"jsnext:main"` and `"jsnext"` fields are deprecated. The `"module"` field should be used instead. See [this issue](https://github.com/jsforum/jsforum/issues/5) for more information.

--- a/site/rules.md
+++ b/site/rules.md
@@ -226,3 +226,7 @@ When matching the `"worker"` condition, it will resolve to `"./lib.server.js"` w
 This is usually not intended and causes the wrong file to be loaded. If it is intended, the `"worker"` condition should point to `"./lib.browser.js"` directly instead.
 
 To fix this, you can rename `"./lib.server.js"` to `"./lib.worker.js"` for example so it has its own specific file. Or check out the [USE_EXPORTS_OR_IMPORTS_BROWSER](#use_exports_or_imports_browser) rule to refactor away the `"browser"` field.
+
+## `DEPRECATED_FIELD_JSNEXT`
+
+`"jsnext:main"` field and `"jsnext"` field are deprecated. `"module"` field should be used instead.

--- a/site/src/utils/message.js
+++ b/site/src/utils/message.js
@@ -142,9 +142,8 @@ function messageToString(m, pkg) {
       // prettier-ignore
       return `${bold(pv(m.path))} matches ${bold(fp(m.args.browserPath))}: "${bold(pv(m.args.browserPath))}", which overrides the path when building the library with the "${bold(m.args.browserishCondition)}" condition. This is usually unintentional and may cause build issues. Consider using a different file name for ${bold(pv(m.path))}.`
     case 'DEPRECATED_FIELD_JSNEXT':
-      return `${bold(fp(m.path))} is deprecated. ${bold(
-        'pkg.module'
-      )} should be used instead.`
+      // prettier-ignore
+      return `${bold(fp(m.path))} is deprecated. ${bold('pkg.module')} should be used instead.`
     default:
       return
   }

--- a/site/src/utils/message.js
+++ b/site/src/utils/message.js
@@ -141,6 +141,10 @@ function messageToString(m, pkg) {
     case 'EXPORTS_VALUE_CONFLICTS_WITH_BROWSER':
       // prettier-ignore
       return `${bold(pv(m.path))} matches ${bold(fp(m.args.browserPath))}: "${bold(pv(m.args.browserPath))}", which overrides the path when building the library with the "${bold(m.args.browserishCondition)}" condition. This is usually unintentional and may cause build issues. Consider using a different file name for ${bold(pv(m.path))}.`
+    case 'DEPRECATED_FIELD_JSNEXT':
+      return `${bold(fp(m.path))} is deprecated. ${bold(
+        'pkg.module'
+      )} should be used instead.`
     default:
       return
   }


### PR DESCRIPTION
`jsnext` and `jsnext:main` fields are superseded by `module` field (https://github.com/jsforum/jsforum/issues/5, https://github.com/rollup/rollup/wiki/pkg.module#:~:text=(Note%3A%20Tools%20such%20as%20rollup%2Dplugin%2Dnode%2Dresolve%20and%20Webpack%202%20treat%20jsnext%3Amain%20and%20module%20interchangeably.%20They%27re%20the%20same%20thing%2C%20except%20that%20module%20is%20more%20likely%20to%20become%20standardised.)).
This PR adds a warning for those fields.
