### PR TITLE
feat: Format message without color

### DIFF
--- a/pkg/index.d.ts
+++ b/pkg/index.d.ts
@@ -148,3 +148,10 @@ export interface Result {
 }
 
 export declare function publint(options?: Options): Promise<Result>
+
+export interface FormatOptions {
+  /**
+   * Generate raw message (without color or bold).
+   */
+  raw?: boolean
+}

--- a/pkg/src/message.js
+++ b/pkg/src/message.js
@@ -1,15 +1,22 @@
-import c from 'picocolors'
+import { createColors } from 'picocolors'
 import {
   formatMessagePath as fp,
   getPkgPathValue,
   replaceLast
 } from './utils.js'
 
+// picocolors with colors (if supported) and without colors.
+const picoColors = createColors()
+const picoNoColors = createColors(false)
+
 /**
  * @param {import('../index.d.ts').Message} m
  * @param {import('./utils.js').Pkg} pkg
+ * @param {import('../index.d.ts').FormatOptions} [options]
  */
-export function formatMessage(m, pkg) {
+export function formatMessage(m, pkg, { raw } = {}) {
+  const c = raw ? picoNoColors : picoColors
+
   /** @param {string[]} path */
   const pv = (path) => getPkgPathValue(pkg, path)
 


### PR DESCRIPTION
The `formatMessage()` function returns the text: `"^[[1mpkg.exports["./array"].import[0]^[[22m is ^[[1m./array.js^[[22m and is written in ^[[33mESM^[[39m, but is interpreted as ^[[33mCJS^[[39m. Consider using the ^[[33m.mjs^[[39m extension, e.g. ^[[1m./array.mjs^[[22m"` (with ANSI escape codes). This pull request adds an option to the function to return the message's plain text: `"pkg.exports["./array"].import[0] is ./array.js and is written in ESM, but is interpreted as CJS. Consider using the .mjs extension, e.g. ./array.mjs"`.

For context: I'm developing [Metalint](https://github.com/regseb/metalint), a tool that aggregates the results of several linters. I'd like to integrate publint, but the color and bold in the messages are a problem (e.g. when the results are written in a file).