### PR TITLE
Correctly process the pack option

### DIFF
--- a/.changeset/warm-dingos-sparkle.md
+++ b/.changeset/warm-dingos-sparkle.md
@@ -2,4 +2,4 @@
 'publint': patch
 ---
 
-fix: correctly process --pack option
+Correctly process the `pack` option

--- a/.changeset/warm-dingos-sparkle.md
+++ b/.changeset/warm-dingos-sparkle.md
@@ -1,0 +1,5 @@
+---
+'publint': patch
+---
+
+fix: correctly process --pack option

--- a/packages/publint/src/cli.js
+++ b/packages/publint/src/cli.js
@@ -133,7 +133,7 @@ async function lintDir(pkgDir, level, strict, pack, compact = false) {
   if (!rootPkgContent) return logs
   const rootPkg = JSON.parse(rootPkgContent)
   const pkgName = rootPkg.name || path.basename(pkgDir)
-  const { messages } = await publint({ pkgDir, level, pack, strict })
+  const { messages } = await publint({ pkgDir, level, strict, pack })
 
   if (messages.length) {
     const suggestions = messages.filter((v) => v.type === 'suggestion')

--- a/packages/publint/src/cli.js
+++ b/packages/publint/src/cli.js
@@ -85,7 +85,16 @@ cli
       pq.push(async () => {
         const depDir = await findDepPath(deps[i], pkgDir)
         const logs = depDir
-          ? await lintDir(depDir, opts.level, opts.strict, opts.pack, true)
+          ? await lintDir(
+              depDir,
+              opts.level,
+              opts.strict,
+              // Linting dependencies in node_modules also means that the dependency
+              // is already packed, so we don't need to pack it again by passing `false`.
+              // Otherwise if it's a local-linked dependency, we use the pack option.
+              depDir.includes('node_modules') ? false : opts.pack,
+              true
+            )
           : []
         // log this lint result
         const log = () => {

--- a/packages/publint/src/cli.js
+++ b/packages/publint/src/cli.js
@@ -33,7 +33,7 @@ cli
     opts = normalizeOpts(opts)
 
     const pkgDir = dir ? path.resolve(dir) : process.cwd()
-    const logs = await lintDir(pkgDir, opts.level, opts.strict)
+    const logs = await lintDir(pkgDir, opts.level, opts.strict, opts.pack)
     logs.forEach((l) => console.log(l))
   })
 
@@ -85,7 +85,7 @@ cli
       pq.push(async () => {
         const depDir = await findDepPath(deps[i], pkgDir)
         const logs = depDir
-          ? await lintDir(depDir, opts.level, opts.strict, true)
+          ? await lintDir(depDir, opts.level, opts.strict, opts.pack, true)
           : []
         // log this lint result
         const log = () => {
@@ -117,9 +117,10 @@ cli.parse(process.argv)
  * @param {string} pkgDir
  * @param {import('./index.js').Options['level']} level
  * @param {import('./index.js').Options['strict']} strict
+ * @param {import('./index.js').Options['pack']} pack
  * @param {boolean} [compact]
  */
-async function lintDir(pkgDir, level, strict, compact = false) {
+async function lintDir(pkgDir, level, strict, pack, compact = false) {
   /** @type {string[]} */
   const logs = []
 
@@ -132,7 +133,7 @@ async function lintDir(pkgDir, level, strict, compact = false) {
   if (!rootPkgContent) return logs
   const rootPkg = JSON.parse(rootPkgContent)
   const pkgName = rootPkg.name || path.basename(pkgDir)
-  const { messages } = await publint({ pkgDir, level, strict })
+  const { messages } = await publint({ pkgDir, level, pack, strict })
 
   if (messages.length) {
     const suggestions = messages.filter((v) => v.type === 'suggestion')

--- a/packages/publint/src/index-node.js
+++ b/packages/publint/src/index-node.js
@@ -34,7 +34,12 @@ export async function publint(options) {
     if (pack !== false) {
       const pkgDir = options?.pkgDir ?? process.cwd()
 
-      let packageManager = (await detect({ cwd: pkgDir }))?.name
+      let packageManager = pack
+
+      if (packageManager === 'auto') {
+        packageManager = (await detect({ cwd: pkgDir }))?.name ?? 'npm'
+      }
+
       // Deno is not supported in `@publint/pack` (doesn't have a pack command)
       if (packageManager === 'deno') {
         packageManager = 'npm'

--- a/packages/publint/src/index-node.js
+++ b/packages/publint/src/index-node.js
@@ -35,14 +35,13 @@ export async function publint(options) {
       const pkgDir = options?.pkgDir ?? process.cwd()
 
       let packageManager = pack
-
       if (packageManager === 'auto') {
-        packageManager = (await detect({ cwd: pkgDir }))?.name ?? 'npm'
-      }
-
-      // Deno is not supported in `@publint/pack` (doesn't have a pack command)
-      if (packageManager === 'deno') {
-        packageManager = 'npm'
+        let detected = (await detect({ cwd: pkgDir }))?.name ?? 'npm'
+        // Deno is not supported in `@publint/pack` (doesn't have a pack command)
+        if (detected === 'deno') {
+          detected = 'npm'
+        }
+        packageManager = detected
       }
 
       packedFiles = (await packAsList(pkgDir, { packageManager })).map((file) =>

--- a/packages/publint/src/index.d.ts
+++ b/packages/publint/src/index.d.ts
@@ -151,7 +151,7 @@ export interface Options {
    * entrypoints but not published.
    * - `'auto'`: Automatically detects the package manager using
    *             [`package-manager-detector`](https://github.com/antfu-collective/package-manager-detector).
-   * - `'npm'`/`'yarn'`/`'pnpm'`/`'bun'`: Uses the respective package manager to pack.
+   * - `'npm'`/`'yarn'`/`'pnpm'`/`'deno'`/`'bun'`: Uses the respective package manager to pack.
    * - `{ tarball }`: Packs the package from the specified tarball represented as an ArrayBuffer or ReadableStream.
    * - `{ files }`: Packs the package using the specified files.
    * - `false`: Skips packing the package. This should only be used if all the files
@@ -167,6 +167,7 @@ export interface Options {
     | 'npm'
     | 'yarn'
     | 'pnpm'
+    | 'deno'
     | 'bun'
     | { tarball: ArrayBuffer | ReadableStream<Uint8Array> }
     | { files: PackFile[] }

--- a/packages/publint/src/index.d.ts
+++ b/packages/publint/src/index.d.ts
@@ -151,7 +151,7 @@ export interface Options {
    * entrypoints but not published.
    * - `'auto'`: Automatically detects the package manager using
    *             [`package-manager-detector`](https://github.com/antfu-collective/package-manager-detector).
-   * - `'npm'`/`'yarn'`/`'pnpm'`/`'deno'`/`'bun'`: Uses the respective package manager to pack.
+   * - `'npm'`/`'yarn'`/`'pnpm'`/`'bun'`: Uses the respective package manager to pack.
    * - `{ tarball }`: Packs the package from the specified tarball represented as an ArrayBuffer or ReadableStream.
    * - `{ files }`: Packs the package using the specified files.
    * - `false`: Skips packing the package. This should only be used if all the files
@@ -167,7 +167,6 @@ export interface Options {
     | 'npm'
     | 'yarn'
     | 'pnpm'
-    | 'deno'
     | 'bun'
     | { tarball: ArrayBuffer | ReadableStream<Uint8Array> }
     | { files: PackFile[] }


### PR DESCRIPTION
Currently, the new `--pack` CLI option gets ignored by the publint function, and is also handled incorrectly when the value is not `auto`.

This PR makes 2 changes:
- Pass `--pack` option from CLI into `lintDir`, then into `publint`
- Only use `package-manager-detector` when `pack` is `auto` (otherwise use the manual option, e.g. `--pack npm`)

To make types work, I've needed to add `deno` as a valid option to pass to the CLI, however  this still gets turned into `npm` internally