### PR TITLE
Recognize more internal files in `USE_FILES` check

### DIFF
--- a/.changeset/stale-deer-stop.md
+++ b/.changeset/stale-deer-stop.md
@@ -1,0 +1,5 @@
+---
+'publint': patch
+---
+
+Recognize more common internal files for the `USE_FILES` suggestion.

--- a/packages/publint/src/shared/constants.js
+++ b/packages/publint/src/shared/constants.js
@@ -24,11 +24,40 @@ export const commonInternalPaths = [
   'test/',
   'tests/',
   '__tests__/',
-  // files
+  'e2e/',
+  '.circleci/',
+  '.github/',
+  '.husky/',
+  '.vscode/',
+  // config files
   '.prettierrc',
+  '.prettierignore',
   'prettier.config.js',
   '.eslintrc',
   '.eslintrc.js',
+  '.eslintignore',
+  'eslint.config.js',
+  'eslint.config.mjs',
+  'eslint.config.cjs',
+  // CI files
+  '.travis.yml',
+  'azure-pipelines.yml',
+  'appveyor.yml',
+  // git files
+  '.gitattributes',
+  '.gitignore',
+  // lockfiles
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'bun.lock',
+  'bun.lockb',
+  // misc
+  'CONTRIBUTING.md',
+  'CODE_OF_CONDUCT.md',
+  'CODEOWNERS',
+  'Dockerfile',
+  'tsconfig.tsbuildinfo',
 ]
 
 // https://github.com/npm/npm-packlist/blob/53b2a4f42b7fef0f63e8f26a3ea4692e23a58fed/lib/index.js#L284-L286

--- a/packages/publint/tests/fixtures/use-files.js
+++ b/packages/publint/tests/fixtures/use-files.js
@@ -1,0 +1,15 @@
+export default {
+  'package.json': JSON.stringify({
+    name: 'publint-use-files',
+    version: '0.0.1',
+    private: true,
+    type: 'module',
+    exports: './main.js',
+  }),
+  '.github': {
+    workflows: {
+      'ci.yml': 'name: CI',
+    },
+  },
+  'main.js': "export const foo = 'foo'",
+}

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -108,6 +108,8 @@ testFixture('publish-config-directory', [], { pack: 'pnpm' })
 
 testFixture('npmignore', [])
 
+testFixture('use-files', ['USE_FILES'])
+
 testFixture('test-1', [
   'FILE_INVALID_FORMAT',
   'LOCAL_DEPENDENCY',


### PR DESCRIPTION
extends `commonInternalPaths` with the files such as CI dirs/configs (`.github/`, `.circleci/`, `.travis.yml`, etc.), more lint/format configs, ignore files, lockfiles, and misc stuff like `CONTRIBUTING.md` and `Dockerfile`. 

same rule as before: only fires when "files" isn't set.

> leaving this as note for future ref, reporting which files triggered the warning, recursive *.test.js checks, and the always-on lockfile check are still missing happy to tackle those in follow-ups.

related: #141