### PR TITLE
Report which files triggered `USE_FILES`

### DIFF
--- a/.changeset/true-corners-draw.md
+++ b/.changeset/true-corners-draw.md
@@ -1,0 +1,5 @@
+---
+'publint': patch
+---
+
+The `USE_FILES` message now reports which internal files or directories triggered it via `args.internalFilePaths`

--- a/packages/publint/src/index.d.ts
+++ b/packages/publint/src/index.d.ts
@@ -65,7 +65,7 @@ export type Message =
   | BaseMessage<'USE_ENGINES_NODE'>
   | BaseMessage<'USE_EXPORTS_BROWSER'>
   | BaseMessage<'USE_EXPORTS_OR_IMPORTS_BROWSER'>
-  | BaseMessage<'USE_FILES'>
+  | BaseMessage<'USE_FILES', { internalFilePaths: string[] }>
   | BaseMessage<'USE_SIDE_EFFECTS'>
   | BaseMessage<'USE_TYPE'>
   | BaseMessage<'USE_LICENSE', { licenseFilePath: string }>

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -87,20 +87,24 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
   // Check if package published internal tests or config files
   if (rootPkg.files == null) {
     promiseQueue.push(async () => {
+      /** @type {string[]} */
+      const internalFilePaths = []
       for (const p of commonInternalPaths) {
         const internalPath = vfs.pathJoin(pkgDir, p)
         if (_packedFiles && _packedFiles.every((f) => !f.startsWith(internalPath))) {
           continue
         }
         if (await vfs.isPathExist(internalPath)) {
-          messages.push({
-            code: 'USE_FILES',
-            args: {},
-            path: ['name'],
-            type: 'suggestion',
-          })
-          break
+          internalFilePaths.push('/' + p)
         }
+      }
+      if (internalFilePaths.length > 0) {
+        messages.push({
+          code: 'USE_FILES',
+          args: { internalFilePaths },
+          path: ['name'],
+          type: 'suggestion',
+        })
       }
     })
   }

--- a/packages/publint/src/shared/message.js
+++ b/packages/publint/src/shared/message.js
@@ -130,8 +130,15 @@ export function formatMessage(m, pkg, opts = {}) {
       )
     case 'USE_EXPORTS_OR_IMPORTS_BROWSER':
       return `${h.bold('pkg.browser')} with an object value can be refactored to use ${h.bold('pkg.exports')}/${h.bold('pkg.imports')} and the ${h.bold('"browser"')} condition to declare browser-specific exports. (This may be a breaking change)`
-    case 'USE_FILES':
-      return `The package ${h.bold('publishes internal tests or config files')}. You can use ${h.bold('pkg.files')} to only publish certain files and save user bandwidth.`
+    case 'USE_FILES': {
+      const paths = m.args.internalFilePaths
+      const shown = paths
+        .slice(0, 5)
+        .map((p) => h.bold(p))
+        .join(', ')
+      const rest = paths.length > 5 ? ` and ${paths.length - 5} more` : ''
+      return `The package ${h.bold('publishes internal tests or config files')} (${shown}${rest}). You can use ${h.bold('pkg.files')} to only publish certain files and save user bandwidth.`
+    }
     case 'USE_SIDE_EFFECTS':
       return `The package appears to be consumed by bundlers but does not specify ${h.bold('"sideEffects"')}. Consider adding ${h.bold('"sideEffects"')}: ${h.bold('false')} so bundlers can optimize tree-shaking if your package has no side effects.`
     case 'USE_TYPE':

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -110,15 +110,21 @@ testFixture('npmignore', [])
 
 testFixture('use-files', ['USE_FILES'])
 
-test('use-files reports triggering paths', { concurrent: true }, async ({ expect, onTestFinished }) => {
-  const fixtureContent = (await import(path.resolve(process.cwd(), 'tests/fixtures/use-files.js'))).default
-  const fixture = await createFixture(fixtureContent)
-  onTestFinished(() => fixture.rm())
+test(
+  'use-files reports triggering paths',
+  { concurrent: true },
+  async ({ expect, onTestFinished }) => {
+    const fixtureContent = (
+      await import(path.resolve(process.cwd(), 'tests/fixtures/use-files.js'))
+    ).default
+    const fixture = await createFixture(fixtureContent)
+    onTestFinished(() => fixture.rm())
 
-  const { messages } = await publint({ pkgDir: fixture.path })
-  const msg = messages.find((m) => m.code === 'USE_FILES')
-  expect(msg?.args).toEqual({ internalFilePaths: ['/.github/'] })
-})
+    const { messages } = await publint({ pkgDir: fixture.path })
+    const msg = messages.find((m) => m.code === 'USE_FILES')
+    expect(msg?.args).toEqual({ internalFilePaths: ['/.github/'] })
+  },
+)
 
 testFixture('test-1', [
   'FILE_INVALID_FORMAT',

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -110,6 +110,16 @@ testFixture('npmignore', [])
 
 testFixture('use-files', ['USE_FILES'])
 
+test('use-files reports triggering paths', { concurrent: true }, async ({ expect, onTestFinished }) => {
+  const fixtureContent = (await import(path.resolve(process.cwd(), 'tests/fixtures/use-files.js'))).default
+  const fixture = await createFixture(fixtureContent)
+  onTestFinished(() => fixture.rm())
+
+  const { messages } = await publint({ pkgDir: fixture.path })
+  const msg = messages.find((m) => m.code === 'USE_FILES')
+  expect(msg?.args).toEqual({ internalFilePaths: ['/.github/'] })
+})
+
 testFixture('test-1', [
   'FILE_INVALID_FORMAT',
   'LOCAL_DEPENDENCY',


### PR DESCRIPTION
follow-up to #244 

the `USE_FILES` check now collects every matching internal path instead of stopping at the first hit, and reports them via `args.internalFilePaths` (e.g. /test/, /.gitignore). the formatted message lists the first 5 paths and appends "and N more" beyond that.

related: #141