### PR TITLE
Detect nested test files in `USE_FILES` check

### DIFF
--- a/.changeset/major-pears-matter.md
+++ b/.changeset/major-pears-matter.md
@@ -1,0 +1,5 @@
+---
+'publint': patch
+---
+
+Recursively detect test files (e.g. `*.test.js`, `*.spec.ts`) for the `USE_FILES` suggestion.

--- a/packages/publint/src/node/vfs-node.js
+++ b/packages/publint/src/node/vfs-node.js
@@ -28,7 +28,7 @@ export function createNodeVfs() {
       return nodePath.join(...parts)
     },
     pathRelative(from, to) {
-      return nodePath.relative(from, to)
+      return nodePath.relative(from, to).replaceAll(nodePath.sep, '/')
     },
     getDirName(path) {
       return nodePath.dirname(path)

--- a/packages/publint/src/shared/constants.js
+++ b/packages/publint/src/shared/constants.js
@@ -60,5 +60,9 @@ export const commonInternalPaths = [
   'tsconfig.tsbuildinfo',
 ]
 
+// NOTE: like `commonInternalPaths`, this is intentionally non-exhaustive and
+// loose detection purpose for `pkg.files`.
+export const commonInternalTestFileRegex = /\.(test|spec)\.[cm]?[jt]sx?$/
+
 // https://github.com/npm/npm-packlist/blob/53b2a4f42b7fef0f63e8f26a3ea4692e23a58fed/lib/index.js#L284-L286
 export const licenseFiles = [/^copying/i, /^licence/i, /^license/i]

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -44,7 +44,7 @@ import {
  * @property {(path: string) => Promise<boolean>} isPathDir
  * @property {(path: string) => Promise<boolean>} isPathExist
  * @property {(...paths: string[]) => string} pathJoin
- * @property {(from: string, to: string) => string} pathRelative
+ * @property {(from: string, to: string) => string} pathRelative Returned path uses `/` separators
  * @property {(path: string) => string} getDirName
  * @property {(path: string) => string} getExtName
  */
@@ -1327,8 +1327,7 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
         commonInternalTestFileRegex.test(item) &&
         (!_packedFiles || _packedFiles.includes(itemPath))
       ) {
-        // Normalize Windows separators as the path is joined with `/` below
-        internalTestFilePaths.push('/' + vfs.pathRelative(pkgDir, itemPath).replace(/\\/g, '/'))
+        internalTestFilePaths.push('/' + vfs.pathRelative(pkgDir, itemPath))
       }
       if (item !== 'package.json' || itemPath === rootPkgPath) continue
       if (_packedFiles && !_packedFiles.includes(itemPath)) continue

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -1,5 +1,6 @@
 import {
   commonInternalPaths,
+  commonInternalTestFileRegex,
   invalidJsxExtensions,
   knownBrowserishConditions,
   licenseFiles,
@@ -84,20 +85,42 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
   const [exports, exportsPkgPath] = getPublishedField(rootPkg, 'exports')
   const [imports, importsPkgPath] = getPublishedField(rootPkg, 'imports')
 
+  // Check if any nested package.json files have "exports" or "imports" fields, which
+  // Node.js ignores outside the package root (see https://github.com/nodejs/node/issues/58827).
+  // Some bundlers may still read them which can lead to inconsistent resolution.
+  // The walk also collects nested test files for the `USE_FILES` check below.
+  /** @type {string[]} */
+  const internalTestFilePaths = []
+  const crawlNestedPackageJsonPromise = crawlNestedPackageJson(pkgDir)
+  promiseQueue.push(() => crawlNestedPackageJsonPromise)
+
   // Check if package published internal tests or config files
   if (rootPkg.files == null) {
     promiseQueue.push(async () => {
       /** @type {string[]} */
       const internalFilePaths = []
       for (const p of commonInternalPaths) {
+        // `pathJoin` preserves the trailing slash of directories, so `startsWith`
+        // matches at directory boundaries. Files must match exactly.
         const internalPath = vfs.pathJoin(pkgDir, p)
-        if (_packedFiles && _packedFiles.every((f) => !f.startsWith(internalPath))) {
-          continue
+        if (_packedFiles) {
+          const isPacked = p.endsWith('/')
+            ? _packedFiles.some((f) => f.startsWith(internalPath))
+            : _packedFiles.includes(internalPath)
+          if (!isPacked) continue
         }
         if (await vfs.isPathExist(internalPath)) {
           internalFilePaths.push('/' + p)
         }
       }
+      // Wait for the recursive walk to finish collecting nested test files, then
+      // skip those already covered by a matched directory, e.g. don't report
+      // both `/test/` and `/test/foo.test.js`
+      await crawlNestedPackageJsonPromise
+      const matchedDirs = internalFilePaths.filter((p) => p.endsWith('/'))
+      internalFilePaths.push(
+        ...internalTestFilePaths.filter((p) => !matchedDirs.some((d) => p.startsWith(d))),
+      )
       if (internalFilePaths.length > 0) {
         messages.push({
           code: 'USE_FILES',
@@ -488,13 +511,6 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
   if (imports && ensureTypeOfField(imports, ['object'], importsPkgPath)) {
     crawlExportsOrImports(imports, importsPkgPath, true)
   }
-
-  // Check if any nested package.json files have "exports" or "imports" fields, which
-  // Node.js ignores outside the package root (see https://github.com/nodejs/node/issues/58827).
-  // Some bundlers may still read them which can lead to inconsistent resolution.
-  promiseQueue.push(async () => {
-    await crawlNestedPackageJson(pkgDir)
-  })
 
   await promiseQueue.wait()
 
@@ -1303,6 +1319,14 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
         }
         await crawlNestedPackageJson(itemPath)
         continue
+      }
+      // Piggyback on this walk to also detect nested test files for `USE_FILES`
+      if (
+        rootPkg.files == null &&
+        commonInternalTestFileRegex.test(item) &&
+        (!_packedFiles || _packedFiles.includes(itemPath))
+      ) {
+        internalTestFilePaths.push('/' + vfs.pathRelative(pkgDir, itemPath))
       }
       if (item !== 'package.json' || itemPath === rootPkgPath) continue
       if (_packedFiles && !_packedFiles.includes(itemPath)) continue

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -1321,6 +1321,7 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
         continue
       }
       // Piggyback on this walk to also detect nested test files for `USE_FILES`
+      // TODO: Separate this and optimize multiple walks in the future
       if (
         rootPkg.files == null &&
         commonInternalTestFileRegex.test(item) &&

--- a/packages/publint/src/shared/core.js
+++ b/packages/publint/src/shared/core.js
@@ -1326,7 +1326,8 @@ export async function core({ pkgDir, vfs, level, strict, _packedFiles }) {
         commonInternalTestFileRegex.test(item) &&
         (!_packedFiles || _packedFiles.includes(itemPath))
       ) {
-        internalTestFilePaths.push('/' + vfs.pathRelative(pkgDir, itemPath))
+        // Normalize Windows separators as the path is joined with `/` below
+        internalTestFilePaths.push('/' + vfs.pathRelative(pkgDir, itemPath).replace(/\\/g, '/'))
       }
       if (item !== 'package.json' || itemPath === rootPkgPath) continue
       if (_packedFiles && !_packedFiles.includes(itemPath)) continue

--- a/packages/publint/tests/fixtures/use-files.js
+++ b/packages/publint/tests/fixtures/use-files.js
@@ -11,5 +11,11 @@ export default {
       'ci.yml': 'name: CI',
     },
   },
+  src: {
+    'foo.test.js': "import { foo } from '../main.js'",
+  },
+  test: {
+    'bar.spec.ts': 'export {}',
+  },
   'main.js': "export const foo = 'foo'",
 }

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -108,28 +108,14 @@ testFixture('publish-config-directory', [], { pack: 'pnpm' })
 
 testFixture('npmignore', [])
 
-testFixture('use-files', ['USE_FILES'])
-
-test(
-  'use-files reports triggering paths',
-  { concurrent: true, timeout: process.env.CI ? 8000 : 5000 },
-  async ({ expect, onTestFinished }) => {
-    const fixtureDir = path.resolve(process.cwd(), 'tests/fixtures')
-    const fixtureContent = (await import(path.resolve(fixtureDir, 'use-files.js'))).default
-    const fixture = await createFixture(fixtureContent, {
-      // See `testFixture` on why `tempDir` is set on Windows CI
-      tempDir: isWindowsCI ? fixtureDir : undefined,
-    })
-    onTestFinished(() => fixture.rm())
-
-    const { messages } = await publint({ pkgDir: fixture.path })
-    const msg = messages.find((m) => m.code === 'USE_FILES')
-    // `/test/bar.spec.ts` is not reported as it's covered by `/test/` already
-    expect(msg?.args).toEqual({
-      internalFilePaths: ['/test/', '/.github/', '/src/foo.test.js'],
-    })
+// `/test/bar.spec.ts` is not reported as it's covered by `/test/` already
+testFixture('use-files', [
+  {
+    code: 'USE_FILES',
+    type: 'suggestion',
+    args: { internalFilePaths: ['/test/', '/.github/', '/src/foo.test.js'] },
   },
-)
+])
 
 testFixture('test-1', [
   'FILE_INVALID_FORMAT',
@@ -291,7 +277,7 @@ testFixture('nested-package-json', [
 
 /**
  * @param {string} name
- * @param {import('../src/index.d.ts').Message['code'][] | Pick<import('../src/index.d.ts').Message, 'code' | 'type'>[]} expectCodes
+ * @param {import('../src/index.d.ts').Message['code'][] | (Pick<import('../src/index.d.ts').Message, 'code' | 'type'> & Partial<Pick<import('../src/index.d.ts').Message, 'args'>>)[]} expectCodes
  * @param {TestOptions} [options]
  */
 function testFixture(name, expectCodes, options) {
@@ -332,10 +318,9 @@ function testFixture(name, expectCodes, options) {
       console.log()
     }
 
-    // you can test an array of objects
+    // you can test an array of objects (matched partially, e.g. `args` is optional)
     if (typeof expectCodes[0] === 'object') {
-      const codes = messages.map((v) => ({ code: v.code, type: v.type }))
-      expect(codes).toEqual(expectCodes)
+      expect(messages).toMatchObject(expectCodes)
     } else {
       const codes = messages.map((v) => v.code)
       expect(codes).toEqual(expectCodes)

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -122,7 +122,10 @@ test(
 
     const { messages } = await publint({ pkgDir: fixture.path })
     const msg = messages.find((m) => m.code === 'USE_FILES')
-    expect(msg?.args).toEqual({ internalFilePaths: ['/.github/'] })
+    // `/test/bar.spec.ts` is not reported as it's covered by `/test/` already
+    expect(msg?.args).toEqual({
+      internalFilePaths: ['/test/', '/.github/', '/src/foo.test.js'],
+    })
   },
 )
 

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -115,8 +115,7 @@ test(
   { concurrent: true, timeout: process.env.CI ? 8000 : 5000 },
   async ({ expect, onTestFinished }) => {
     const fixtureDir = path.resolve(process.cwd(), 'tests/fixtures')
-    const fixtureContent = (await import(path.resolve(fixtureDir, 'use-files.js')))
-      .default
+    const fixtureContent = (await import(path.resolve(fixtureDir, 'use-files.js'))).default
     const fixture = await createFixture(fixtureContent, {
       // See `testFixture` on why `tempDir` is set on Windows CI
       tempDir: isWindowsCI ? fixtureDir : undefined,

--- a/packages/publint/tests/playground.test.js
+++ b/packages/publint/tests/playground.test.js
@@ -112,12 +112,15 @@ testFixture('use-files', ['USE_FILES'])
 
 test(
   'use-files reports triggering paths',
-  { concurrent: true },
+  { concurrent: true, timeout: process.env.CI ? 8000 : 5000 },
   async ({ expect, onTestFinished }) => {
-    const fixtureContent = (
-      await import(path.resolve(process.cwd(), 'tests/fixtures/use-files.js'))
-    ).default
-    const fixture = await createFixture(fixtureContent)
+    const fixtureDir = path.resolve(process.cwd(), 'tests/fixtures')
+    const fixtureContent = (await import(path.resolve(fixtureDir, 'use-files.js')))
+      .default
+    const fixture = await createFixture(fixtureContent, {
+      // See `testFixture` on why `tempDir` is set on Windows CI
+      tempDir: isWindowsCI ? fixtureDir : undefined,
+    })
     onTestFinished(() => fixture.rm())
 
     const { messages } = await publint({ pkgDir: fixture.path })

--- a/site/src/pages/rules.md
+++ b/site/src/pages/rules.md
@@ -405,7 +405,7 @@ Depending on your setup, you can also use the `"exports"` field to directly expo
 
 ### `USE_FILES` <RuleType type="suggestion" />
 
-Internal tests or config files are published, which are usually not needed and unused. Besides common top-level files and directories, test files (e.g. `*.test.js`, `*.spec.ts`) anywhere in the package also trigger this suggestion. You can use the [`"files"` field](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files) to only publish certain files. For example:
+Internal tests or config files are published, which are usually not needed and unused. You can use the [`"files"` field](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files) to only publish certain files. For example:
 
 ```json
 {

--- a/site/src/pages/rules.md
+++ b/site/src/pages/rules.md
@@ -405,7 +405,7 @@ Depending on your setup, you can also use the `"exports"` field to directly expo
 
 ### `USE_FILES` <RuleType type="suggestion" />
 
-Internal tests or config files are published, which are usually not needed and unused. You can use the [`"files"` field](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files) to only publish certain files. For example:
+Internal tests or config files are published, which are usually not needed and unused. Besides common top-level files and directories, test files (e.g. `*.test.js`, `*.spec.ts`) anywhere in the package also trigger this suggestion. You can use the [`"files"` field](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files) to only publish certain files. For example:
 
 ```json
 {


### PR DESCRIPTION
this tackles the last piece of #141 which recursively detects test files like `*.test.js` / `*.spec.ts` anywhere in the package.

closes: #141 